### PR TITLE
Add module field for ESM distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Utility functions",
   "main": "cjs/should-util.js",
+  "module": "es6/should-util.js",
   "jsnext:main": "es6/should-util.js",
   "scripts": {
     "cjs": "rollup --format=cjs --output=cjs/should-util.js index.js",


### PR DESCRIPTION
As far as I can tell, `jsnext:main` is deprecated in favor of `module` (see https://github.com/rollup/rollup/wiki/pkg.module and https://github.com/rollup/rollup-plugin-node-resolve/pull/209).

Just to be safe, I decided to duplicate rather than replace the `jsnext:main` field - not sure whether that's actually necessary though.